### PR TITLE
[BRUSH] Concept Test: Added a "spray" brush function

### DIFF
--- a/shc-mapeditortools.lua
+++ b/shc-mapeditortools.lua
@@ -1,8 +1,47 @@
 MIRROR_MODE = "point"
 MIRROR_MODE2 = "off"
 
+-- brush config
+BRUSH = "normal"
+BRUSH_SPRAY_EXP = 3 -- defines how centered the random positions should be (higher -> more centered, should be bigger than 1)
+BRUSH_SPRAY_SIZE = 8 -- TEMP? Would need reliable way to get the set brush size, regardless of the action
+BRUSH_SPRAY_INT = 0.25 -- intensity -> 0 to 1, if random number bigger, skips the draw call
+
+
+-- helper 
+
+-- source: https://scriptinghelpers.org/questions/4850/how-do-i-round-numbers-in-lua-answered
+function round(x)
+  return x + 0.5 - (x + 0.5) % 1
+end
+
+-- generates a random deviation for the spray brush using the size
+function randomSprayDeviation(size)
+  local rand = round((math.random()^BRUSH_SPRAY_EXP) * size)
+  rand = math.random() < 0.5 and -rand or rand -- plus or minus
+  return rand
+end
+
+-- helper end
+
+
 function applyMirrors(x, y, size)
-  coordlist = {{x,y}}
+  coordlist = {}
+  
+  -- apply spray brush, position does not feel really right in applyMirrors, though
+  if BRUSH == "spray" then
+  
+    -- return empty coordlist to skip drawing
+    if math.random() > BRUSH_SPRAY_INT then
+      return coordlist
+    end
+  
+    x = x + randomSprayDeviation(BRUSH_SPRAY_SIZE)
+    y = y + randomSprayDeviation(BRUSH_SPRAY_SIZE)
+  end
+  
+  table.insert(coordlist, {x,y})
+  
   if MIRROR_MODE ~= "off" then
     table.insert(coordlist, applyMirror(x, y, size, MIRROR_MODE))
     if MIRROR_MODE2 ~= "off" then


### PR DESCRIPTION
Can be activated by setting the value of "BRUSH" to "spray". (Other values do nothing.)

(Repeat of commit message: )
- A little misplaced in the code at the moment, though.
- No documentation added. ("help" is not editable anyway...) 
- Spray (if active) is applied to all actions that are also mirrored.
- Spray shape (region) is that of a rhombus.
- Hard to configure currently.
- Config is not protected at all.